### PR TITLE
Root compartment misnomer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+lib64
+lib/
+bin/
+include/
+pyvenv.cfg

--- a/ocimodules/IAM.py
+++ b/ocimodules/IAM.py
@@ -44,7 +44,7 @@ def Login(config, signer, startcomp):
     c = []
 
     # Adding Start compartment
-    if "user" in config and not ".tenancy." in startcomp:
+    if "user" in config or ".tenancy." not in startcomp:
         compartment = identity.get_compartment(compartment_id=startcomp, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY).data
     else:
         # Bug fix - for working on root compartment using instance principle.


### PR DESCRIPTION
Currently if you are deleting a subcompartment via instance principle or delegation token the name of the compartment will be 'root' which is makes it seem like your deleting everything in the tenancy.