### PR TITLE
Allow rerunning script against "DELETING" compartment

### DIFF
--- a/delete.py
+++ b/delete.py
@@ -155,7 +155,7 @@ compartments = Login(config, signer, DeleteCompartmentOCID)
 processCompartments = []
 processRootCompartment = []
 for compartment in compartments:
-    if compartment.details.lifecycle_state == "ACTIVE" and compartment.details.name != "ManagedCompartmentForPaaS":
+    if (compartment.details.lifecycle_state == "ACTIVE" or compartment.details.lifecycle_state == "DELETING") and compartment.details.name != "ManagedCompartmentForPaaS":
         processCompartments.append(compartment)
     if compartment.details.id == tenant_id:
         processRootCompartment.append(compartment)


### PR DESCRIPTION
Sometimes you need to run it several times, and when running with `-delete-self` this causes the compartment to go in to DELETING status immediately, though it will eventually fail. This allows running the script against a compartment that is already DELETING.